### PR TITLE
Feat/hng 26 latest article card component

### DIFF
--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@remix-run/react";
+
 interface props {
     title: string;
     description: string;
@@ -12,47 +14,49 @@ interface props {
 
 export default function LatestArticle({ article }: { article: props }) {
     return (
-        <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
-            <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
-                <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
-                    <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
-                        <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
-                        <div className="uppercase">
-                            {article.tag}
-                        </div>
-                    </span>
+        <Link to={article.link}>
+            <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
+                <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
+                    <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
+                        <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
+                            <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+                            <div className="uppercase">
+                                {article.tag}
+                            </div>
+                        </span>
 
-                    <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
-                        {article.title}
-                    </h3>
+                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
+                            {article.title}
+                        </h3>
 
-                    <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
-                        {article.description}
-                    </p>
+                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
+                            {article.description}
+                        </p>
 
-                    <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
-                        <div className="flex items-center gap-[8px]">
-                            <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
-                            <p className="font-[500] text-center">
-                                {article.name}
+                        <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
+                            <div className="flex items-center gap-[8px]">
+                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
+                                <p className="font-[500] text-center">
+                                    {article.name}
+                                </p>
+                            </div>
+                            <p className="text-center">
+                                {article.time}
+                                {" "}
+                                Read
+                            </p>
+
+                            <p className="text-center">
+                                {article.creationDate}
                             </p>
                         </div>
-                        <p className="text-center">
-                            {article.time}
-                            {" "}
-                            Read
-                        </p>
 
-                        <p className="text-center">
-                            {article.creationDate}
-                        </p>
                     </div>
-
+                    <div className="flex items-center">
+                        <img src={article.image} alt={article.title} className="w-full md:h-[300px] h-[250px] object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
+                    </div>
                 </div>
-                <div className="flex items-stretch">
-                    <img src={article.image} alt={article.title} className="w-full h-full object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
-                </div>
-            </div>
-        </article>
+            </article>
+        </Link>
     )
 }

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -29,7 +29,7 @@ export default function LatestArticle({ article }: { article: props }) {
                             {article.title}
                         </h3>
 
-                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
+                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal] tracking-wide">
                             {article.description}
                         </p>
 

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -15,9 +15,9 @@ interface props {
 export default function LatestArticle({ article }: { article: props }) {
     return (
         <Link to={article.link}>
-            <article className="text-muted-foreground max-w-[1000px] bg-[#fafafa]">
-                <div className="grid md:grid-cols-2 gap-[24px] md:py-[32px] py-[16px]">
-                    <div className="order-2 md:order-1 space-y-[8px] md:space-y-[16px]">
+            <article className="text-muted-foreground max-w-[792px] bg-[#fafafa]">
+                <div className="grid md:grid-cols-5 gap-[24px] md:py-[32px] py-[16px]">
+                    <div className="order-2 md:order-1 md:col-span-3 space-y-[8px] md:space-y-[16px]">
                         <span className="bg-border pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
                             <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
                             <div className="uppercase">
@@ -25,7 +25,7 @@ export default function LatestArticle({ article }: { article: props }) {
                             </div>
                         </span>
 
-                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
+                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal] tracking-wider">
                             {article.title}
                         </h3>
 
@@ -52,7 +52,7 @@ export default function LatestArticle({ article }: { article: props }) {
                         </div>
 
                     </div>
-                    <div className="order-1 md:order-2 flex md:items-end">
+                    <div className="order-1 md:order-2 md:col-span-2 flex md:items-end">
                         <img src={article.image} alt={article.title} className="w-full md:h-[250px] h-[230px] object-cover rounded-[6px] md:rounded-[8px]" />
                     </div>
                 </div>

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -15,10 +15,10 @@ interface props {
 export default function LatestArticle({ article }: { article: props }) {
     return (
         <Link to={article.link}>
-            <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
-                <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
-                    <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
-                        <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
+            <article className="text-muted-foreground max-w-[1000px] bg-[#fafafa]">
+                <div className="grid md:grid-cols-2 gap-[24px] md:py-[32px] py-[16px]">
+                    <div className="order-2 md:order-1 space-y-[8px] md:space-y-[16px]">
+                        <span className="bg-border pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
                             <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
                             <div className="uppercase">
                                 {article.tag}
@@ -33,27 +33,27 @@ export default function LatestArticle({ article }: { article: props }) {
                             {article.description}
                         </p>
 
-                        <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
-                            <div className="flex items-center gap-[8px]">
-                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
-                                <p className="font-[500] text-center">
+                        <div className="flex md:justify-between items-center gap-[16px] md:gap-0 flex-wrap font-[500] text-[14px] md:text-[16px]">
+                            <div className="flex items-center gap-[12px] w-full md:w-auto order-3 md:order-1">
+                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[32px] md:w-[40px] h-[32px] md:h-[40px] object-cover object-top" />
+                                <p className="">
                                     {article.name}
                                 </p>
                             </div>
-                            <p className="text-center">
+                            <p className="order-1 md:order-2">
                                 {article.time}
                                 {" "}
                                 Read
                             </p>
 
-                            <p className="text-center">
+                            <p className="order-2 md:order-3">
                                 {article.creationDate}
                             </p>
                         </div>
 
                     </div>
-                    <div className="flex items-center">
-                        <img src={article.image} alt={article.title} className="w-full md:h-[300px] h-[250px] object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
+                    <div className="order-1 md:order-2 flex md:items-end">
+                        <img src={article.image} alt={article.title} className="w-full md:h-[250px] h-[230px] object-cover rounded-[6px] md:rounded-[8px]" />
                     </div>
                 </div>
             </article>

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,0 +1,58 @@
+interface props {
+    title: string;
+    description: string;
+    profileImage: string;
+    name: string;
+    time: string;
+    creationDate: string;
+    image: string;
+    link: string;
+    tag: string;
+}
+
+export default function LatestArticle({ article }: { article: props }) {
+    return (
+        <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
+            <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
+                <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
+                    <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
+                        <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+                        <div className="uppercase">
+                            {article.tag}
+                        </div>
+                    </span>
+
+                    <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
+                        {article.title}
+                    </h3>
+
+                    <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
+                        {article.description}
+                    </p>
+
+                    <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
+                        <div className="flex items-center gap-[8px]">
+                            <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
+                            <p className="font-[500] text-center">
+                                {article.name}
+                            </p>
+                        </div>
+                        <p className="text-center">
+                            {article.time}
+                            {" "}
+                            Read
+                        </p>
+
+                        <p className="text-center">
+                            {article.creationDate}
+                        </p>
+                    </div>
+
+                </div>
+                <div className="flex items-stretch">
+                    <img src={article.image} alt={article.title} className="w-full h-full object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
+                </div>
+            </div>
+        </article>
+    )
+}


### PR DESCRIPTION
Implemented the latest article card component as seen in the figma design which receives the following props:

title: string;
description: string;
profileImage: string;
name: string;
time: string;
creationDate: string;
image: string;
link: string;
tag: string;
The component can be located at /app/components/article/LatestArticle.tsx

This is the link to the design
[https://www.figma.com/design/VEItfX6St5NSAqqNHImcxD/HNG-Boilerplate-Designs?node-id=2202-25505&m=dev](https://www.figma.com/design/VEItfX6St5NSAqqNHImcxD/HNG-Boilerplate-Designs?node-id=2202-25505&m=dev)

Below are the images to the developed component and the lint image

![design](https://github.com/user-attachments/assets/faf80a71-66d0-4f8c-af29-16789c16829c)

![lint](https://github.com/user-attachments/assets/d6c4e423-39c1-4d47-90d5-054f3ba96e73)
