### PR TITLE
Feat/hng 26 latest article card component

### DIFF
--- a/app/components/BlogCards.tsx
+++ b/app/components/BlogCards.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-interface BlogCardProps {
+interface BlogCardProperties {
   title: string;
   description: string;
   date: string;
@@ -12,7 +12,7 @@ interface BlogCardProps {
   link: string;
 }
 
-const BlogCard: React.FC<BlogCardProps> = ({
+const BlogCard: React.FC<BlogCardProperties> = ({
   title,
   description,
   date,
@@ -24,31 +24,31 @@ const BlogCard: React.FC<BlogCardProps> = ({
   link,
 }) => {
   return (
-    <div className="max-w-sm lg:max-w-full lg:flex lg:flex-row rounded overflow-hidden shadow-lg m-4">
-      <img className="w-full lg:w-1/3 lg:order-2" src={blogImage} alt={title} />
-      <div className="p-4 lg:w-2/3 lg:order-1">
-        <div className="flex items-center mb-2">
-          <span className="inline-block w-3 h-3 rounded-full bg-gray-400 mr-2"></span>
+    <div className="m-4 max-w-sm overflow-hidden rounded shadow-lg lg:flex lg:max-w-full lg:flex-row">
+      <img className="w-full lg:order-2 lg:w-1/3" src={blogImage} alt={title} />
+      <div className="p-4 lg:order-1 lg:w-2/3">
+        <div className="mb-2 flex items-center">
+          <span className="mr-2 inline-block h-3 w-3 rounded-full bg-gray-400"></span>
           <span className="text-sm font-semibold text-gray-700">{tag}</span>
         </div>
         <div>
           <a href={link} className="text-black hover:text-blue-800">
-            <h3 className="font-bold text-xl mb-2">{title}</h3>
+            <h3 className="mb-2 text-xl font-bold">{title}</h3>
           </a>
-          <p className="text-gray-700 text-base mb-4">{description}</p>
+          <p className="mb-4 text-base text-gray-700">{description}</p>
         </div>
-        <div className="flex justify-between text-gray-500 text-sm mb-4">
+        <div className="mb-4 flex justify-between text-sm text-gray-500">
           <span>{date}</span>
           <span>{timeOfReading} mins Read</span>
         </div>
         <div className="flex items-center">
           <img
-            className="w-10 h-10 rounded-full mr-4"
+            className="mr-4 h-10 w-10 rounded-full"
             src={authorProfilePicture}
             alt={authorName}
           />
           <div className="text-sm">
-            <p className="text-gray-900 leading-none">{authorName}</p>
+            <p className="leading-none text-gray-900">{authorName}</p>
           </div>
         </div>
       </div>

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -21,27 +21,27 @@ export default function LatestArticle({
   return (
     <Link to={article.link}>
       <article className="max-w-[792px] bg-[#fafafa] text-muted-foreground">
-        <div className="grid gap-[24px] py-[16px] md:grid-cols-5 md:py-[32px]">
-          <div className="order-2 space-y-[8px] md:order-1 md:col-span-3 md:space-y-[16px]">
-            <span className="inline-flex items-center justify-center gap-[6px] rounded-full bg-border py-[4px] pl-[10px] pr-[12px] text-[12px] font-[700]">
-              <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+        <div className="grid gap-6 py-4 md:grid-cols-5 md:py-8">
+          <div className="order-2 space-y-2 md:order-1 md:col-span-3 md:space-y-4">
+            <span className="inline-flex items-center justify-center gap-1.5 rounded-full bg-border py-1 pl-2.5 pr-3 text-xs font-[700]">
+              <span className="h-2 w-2 rounded-full bg-black"></span>
               <div className="uppercase">{article.tag}</div>
             </span>
 
-            <h3 className="text-[20px] font-[700] capitalize leading-[normal] tracking-wider md:text-[28px] md:font-[600]">
+            <h3 className="text-xl font-[700] capitalize leading-[normal] tracking-wider md:text-3xl md:font-[600]">
               {article.title}
             </h3>
 
-            <p className="text-[14px] font-[400] leading-[normal] tracking-wide md:text-[18px]">
+            <p className="text-base font-[400] leading-[normal] tracking-wide md:text-lg">
               {article.description}
             </p>
 
-            <div className="flex flex-wrap items-center gap-[16px] text-[14px] font-[500] md:justify-between md:gap-0 md:text-[16px]">
-              <div className="order-3 flex w-full items-center gap-[12px] md:order-1 md:w-auto">
+            <div className="flex flex-wrap items-center gap-4 text-base font-[500] md:justify-between md:gap-0 md:text-lg">
+              <div className="order-3 flex w-full items-center gap-3 md:order-1 md:w-auto">
                 <img
                   src={article.profileImage}
                   alt={article.name}
-                  className="h-[32px] w-[32px] rounded-full object-cover object-top md:h-[40px] md:w-[40px]"
+                  className="h-8 w-8 rounded-full object-cover object-top md:h-10 md:w-10"
                 />
                 <p className="">{article.name}</p>
               </div>
@@ -57,7 +57,7 @@ export default function LatestArticle({
             <img
               src={article.image}
               alt={article.title}
-              className="h-[230px] w-full rounded-[6px] object-cover md:h-[250px] md:rounded-[8px]"
+              className="md:rounded-2 h-60 w-full rounded-lg object-cover md:h-60"
             />
           </div>
         </div>

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@remix-run/react";
 
 interface articleProperties {
+  id: string;
   title: string;
   description: string;
   profileImage: string;

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@remix-run/react";
+
 interface props {
     title: string;
     description: string;
@@ -12,47 +14,49 @@ interface props {
 
 export default function LatestArticle({ article }: { article: props }) {
     return (
-        <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
-            <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
-                <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
-                    <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
-                        <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
-                        <div className="uppercase">
-                            {article.tag}
-                        </div>
-                    </span>
+        <Link to={article.link}>
+            <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
+                <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
+                    <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
+                        <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
+                            <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+                            <div className="uppercase">
+                                {article.tag}
+                            </div>
+                        </span>
 
-                    <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
-                        {article.title}
-                    </h3>
+                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
+                            {article.title}
+                        </h3>
 
-                    <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
-                        {article.description}
-                    </p>
+                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
+                            {article.description}
+                        </p>
 
-                    <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
-                        <div className="flex items-center gap-[8px]">
-                            <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
-                            <p className="font-[500] text-center">
-                                {article.name}
+                        <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
+                            <div className="flex items-center gap-[8px]">
+                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
+                                <p className="font-[500] text-center">
+                                    {article.name}
+                                </p>
+                            </div>
+                            <p className="text-center">
+                                {article.time}
+                                {" "}
+                                Read
+                            </p>
+
+                            <p className="text-center">
+                                {article.creationDate}
                             </p>
                         </div>
-                        <p className="text-center">
-                            {article.time}
-                            {" "}
-                            Read
-                        </p>
 
-                        <p className="text-center">
-                            {article.creationDate}
-                        </p>
                     </div>
-
+                    <div className="flex items-center">
+                        <img src={article.image} alt={article.title} className="w-full md:h-[300px] h-[250px] object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
+                    </div>
                 </div>
-                <div className="flex items-stretch">
-                    <img src={article.image} alt={article.title} className="w-full h-full object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
-                </div>
-            </div>
-        </article>
+            </article>
+        </Link>
     )
 }

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,65 +1,67 @@
 import { Link } from "@remix-run/react";
 
-interface props {
-    title: string;
-    description: string;
-    profileImage: string;
-    name: string;
-    time: string;
-    creationDate: string;
-    image: string;
-    link: string;
-    tag: string;
+interface articleProperties {
+  id: string;
+  title: string;
+  description: string;
+  profileImage: string;
+  name: string;
+  time: string;
+  creationDate: string;
+  image: string;
+  link: string;
+  tag: string;
 }
 
-export default function LatestArticle({ article }: { article: props }) {
-    return (
-        <Link to={article.link}>
-            <article className="text-muted-foreground max-w-[792px] bg-[#fafafa]">
-                <div className="grid md:grid-cols-5 gap-[24px] md:py-[32px] py-[16px]">
-                    <div className="order-2 md:order-1 md:col-span-3 space-y-[8px] md:space-y-[16px]">
-                        <span className="bg-border pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
-                            <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
-                            <div className="uppercase">
-                                {article.tag}
-                            </div>
-                        </span>
+export default function LatestArticle({
+  article,
+}: {
+  article: articleProperties;
+}) {
+  return (
+    <Link to={article.link}>
+      <article className="max-w-[792px] bg-[#fafafa] text-muted-foreground">
+        <div className="grid gap-[24px] py-[16px] md:grid-cols-5 md:py-[32px]">
+          <div className="order-2 space-y-[8px] md:order-1 md:col-span-3 md:space-y-[16px]">
+            <span className="inline-flex items-center justify-center gap-[6px] rounded-full bg-border py-[4px] pl-[10px] pr-[12px] text-[12px] font-[700]">
+              <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+              <div className="uppercase">{article.tag}</div>
+            </span>
 
-                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal] tracking-wider">
-                            {article.title}
-                        </h3>
+            <h3 className="text-[20px] font-[700] capitalize leading-[normal] tracking-wider md:text-[28px] md:font-[600]">
+              {article.title}
+            </h3>
 
-                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal] tracking-wide">
-                            {article.description}
-                        </p>
+            <p className="text-[14px] font-[400] leading-[normal] tracking-wide md:text-[18px]">
+              {article.description}
+            </p>
 
-                        <div className="flex md:justify-between items-center gap-[16px] md:gap-0 flex-wrap font-[500] text-[14px] md:text-[16px]">
-                            <div className="flex items-center gap-[12px] w-full md:w-auto order-3 md:order-1">
-                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[32px] md:w-[40px] h-[32px] md:h-[40px] object-cover object-top" />
-                                <p className="">
-                                    {article.name}
-                                </p>
-                            </div>
-                            <p className="order-1 md:order-2">
-                                {article.time}
-                                {" "}
-                                Read
-                            </p>
+            <div className="flex flex-wrap items-center gap-[16px] text-[14px] font-[500] md:justify-between md:gap-0 md:text-[16px]">
+              <div className="order-3 flex w-full items-center gap-[12px] md:order-1 md:w-auto">
+                <img
+                  src={article.profileImage}
+                  alt={article.name}
+                  className="h-[32px] w-[32px] rounded-full object-cover object-top md:h-[40px] md:w-[40px]"
+                />
+                <p className="">{article.name}</p>
+              </div>
+              <p className="order-1 md:order-2">{article.time} Read</p>
 
-                            <p className="order-2 md:order-3 flex gap-4 items-center justify-center">
-                                <span className="h-2 w-2 rounded-full bg-border"></span>
-                                <span>
-                                  {article.creationDate}
-                                </span>
-                            </p>
-                        </div>
-
-                    </div>
-                    <div className="order-1 md:order-2 md:col-span-2 flex md:items-end">
-                        <img src={article.image} alt={article.title} className="w-full md:h-[250px] h-[230px] object-cover rounded-[6px] md:rounded-[8px]" />
-                    </div>
-                </div>
-            </article>
-        </Link>
-    )
+              <p className="order-2 flex items-center justify-center gap-4 md:order-3">
+                <span className="h-2 w-2 rounded-full bg-border"></span>
+                <span>{article.creationDate}</span>
+              </p>
+            </div>
+          </div>
+          <div className="order-1 flex md:order-2 md:col-span-2 md:items-end">
+            <img
+              src={article.image}
+              alt={article.title}
+              className="h-[230px] w-full rounded-[6px] object-cover md:h-[250px] md:rounded-[8px]"
+            />
+          </div>
+        </div>
+      </article>
+    </Link>
+  );
 }

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,64 +1,65 @@
 import { Link } from "@remix-run/react";
 
-interface articleProperties {
-  id: string;
-  title: string;
-  description: string;
-  profileImage: string;
-  name: string;
-  time: string;
-  creationDate: string;
-  image: string;
-  link: string;
-  tag: string;
+interface props {
+    title: string;
+    description: string;
+    profileImage: string;
+    name: string;
+    time: string;
+    creationDate: string;
+    image: string;
+    link: string;
+    tag: string;
 }
 
-export default function LatestArticle({
-  article,
-}: {
-  article: articleProperties;
-}) {
-  return (
-    <Link to={article.link}>
-      <article className="max-w-[792px] bg-[#fafafa] text-muted-foreground">
-        <div className="grid gap-[24px] py-[16px] md:grid-cols-5 md:py-[32px]">
-          <div className="order-2 space-y-[8px] md:order-1 md:col-span-3 md:space-y-[16px]">
-            <span className="inline-flex items-center justify-center gap-[6px] rounded-full bg-border py-[4px] pl-[10px] pr-[12px] text-[12px] font-[700]">
-              <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
-              <div className="uppercase">{article.tag}</div>
-            </span>
+export default function LatestArticle({ article }: { article: props }) {
+    return (
+        <Link to={article.link}>
+            <article className="text-muted-foreground max-w-[792px] bg-[#fafafa]">
+                <div className="grid md:grid-cols-5 gap-[24px] md:py-[32px] py-[16px]">
+                    <div className="order-2 md:order-1 md:col-span-3 space-y-[8px] md:space-y-[16px]">
+                        <span className="bg-border pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
+                            <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+                            <div className="uppercase">
+                                {article.tag}
+                            </div>
+                        </span>
 
-            <h3 className="text-[20px] font-[700] capitalize leading-[normal] tracking-wider md:text-[28px] md:font-[600]">
-              {article.title}
-            </h3>
+                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal] tracking-wider">
+                            {article.title}
+                        </h3>
 
-            <p className="text-[14px] font-[400] leading-[normal] tracking-wide md:text-[18px]">
-              {article.description}
-            </p>
+                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal] tracking-wide">
+                            {article.description}
+                        </p>
 
-            <div className="flex flex-wrap items-center gap-[16px] text-[14px] font-[500] md:justify-between md:gap-0 md:text-[16px]">
-              <div className="order-3 flex w-full items-center gap-[12px] md:order-1 md:w-auto">
-                <img
-                  src={article.profileImage}
-                  alt={article.name}
-                  className="h-[32px] w-[32px] rounded-full object-cover object-top md:h-[40px] md:w-[40px]"
-                />
-                <p className="">{article.name}</p>
-              </div>
-              <p className="order-1 md:order-2">{article.time} Read</p>
+                        <div className="flex md:justify-between items-center gap-[16px] md:gap-0 flex-wrap font-[500] text-[14px] md:text-[16px]">
+                            <div className="flex items-center gap-[12px] w-full md:w-auto order-3 md:order-1">
+                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[32px] md:w-[40px] h-[32px] md:h-[40px] object-cover object-top" />
+                                <p className="">
+                                    {article.name}
+                                </p>
+                            </div>
+                            <p className="order-1 md:order-2">
+                                {article.time}
+                                {" "}
+                                Read
+                            </p>
 
-              <p className="order-2 md:order-3">{article.creationDate}</p>
-            </div>
-          </div>
-          <div className="order-1 flex md:order-2 md:col-span-2 md:items-end">
-            <img
-              src={article.image}
-              alt={article.title}
-              className="h-[230px] w-full rounded-[6px] object-cover md:h-[250px] md:rounded-[8px]"
-            />
-          </div>
-        </div>
-      </article>
-    </Link>
-  );
+                            <p className="order-2 md:order-3 flex gap-4 items-center justify-center">
+                                <span className="h-2 w-2 rounded-full bg-border"></span>
+                                <span>
+                                  {article.creationDate}
+                                </span>
+                            </p>
+                        </div>
+
+                    </div>
+                    <div className="order-1 md:order-2 md:col-span-2 flex md:items-end">
+                        <img src={article.image} alt={article.title} className="w-full md:h-[250px] h-[230px] object-cover rounded-[6px] md:rounded-[8px]" />
+                    </div>
+                </div>
+            </article>
+        </Link>
+    )
 }

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -29,7 +29,7 @@ export default function LatestArticle({ article }: { article: props }) {
                             {article.title}
                         </h3>
 
-                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
+                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal] tracking-wide">
                             {article.description}
                         </p>
 

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -15,9 +15,9 @@ interface props {
 export default function LatestArticle({ article }: { article: props }) {
     return (
         <Link to={article.link}>
-            <article className="text-muted-foreground max-w-[1000px] bg-[#fafafa]">
-                <div className="grid md:grid-cols-2 gap-[24px] md:py-[32px] py-[16px]">
-                    <div className="order-2 md:order-1 space-y-[8px] md:space-y-[16px]">
+            <article className="text-muted-foreground max-w-[792px] bg-[#fafafa]">
+                <div className="grid md:grid-cols-5 gap-[24px] md:py-[32px] py-[16px]">
+                    <div className="order-2 md:order-1 md:col-span-3 space-y-[8px] md:space-y-[16px]">
                         <span className="bg-border pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
                             <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
                             <div className="uppercase">
@@ -25,7 +25,7 @@ export default function LatestArticle({ article }: { article: props }) {
                             </div>
                         </span>
 
-                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
+                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal] tracking-wider">
                             {article.title}
                         </h3>
 
@@ -52,7 +52,7 @@ export default function LatestArticle({ article }: { article: props }) {
                         </div>
 
                     </div>
-                    <div className="order-1 md:order-2 flex md:items-end">
+                    <div className="order-1 md:order-2 md:col-span-2 flex md:items-end">
                         <img src={article.image} alt={article.title} className="w-full md:h-[250px] h-[230px] object-cover rounded-[6px] md:rounded-[8px]" />
                     </div>
                 </div>

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -23,20 +23,20 @@ export default function LatestArticle({
       <article className="max-w-[792px] bg-[#fafafa] text-muted-foreground">
         <div className="grid gap-6 py-4 md:grid-cols-5 md:py-8">
           <div className="order-2 space-y-2 md:order-1 md:col-span-3 md:space-y-4">
-            <span className="inline-flex items-center justify-center gap-1.5 rounded-full bg-border py-1 pl-2.5 pr-3 text-xs font-[700]">
+            <span className="inline-flex items-center justify-center gap-1.5 rounded-full bg-border py-1 pl-2.5 pr-3 text-xs font-bold">
               <span className="h-2 w-2 rounded-full bg-black"></span>
               <div className="uppercase">{article.tag}</div>
             </span>
 
-            <h3 className="text-xl font-[700] capitalize leading-[normal] tracking-wider md:text-3xl md:font-[600]">
+            <h3 className="text-xl font-bold capitalize leading-[normal] tracking-wider md:text-3xl md:font-semibold">
               {article.title}
             </h3>
 
-            <p className="text-base font-[400] leading-[normal] tracking-wide md:text-lg">
+            <p className="text-base font-normal leading-[normal] tracking-wide md:text-lg">
               {article.description}
             </p>
 
-            <div className="flex flex-wrap items-center gap-4 text-base font-[500] md:justify-between md:gap-0 md:text-lg">
+            <div className="flex flex-wrap items-center gap-4 text-base font-medium md:justify-between md:gap-0 md:text-lg">
               <div className="order-3 flex w-full items-center gap-3 md:order-1 md:w-auto">
                 <img
                   src={article.profileImage}

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,62 +1,63 @@
 import { Link } from "@remix-run/react";
 
-interface props {
-    title: string;
-    description: string;
-    profileImage: string;
-    name: string;
-    time: string;
-    creationDate: string;
-    image: string;
-    link: string;
-    tag: string;
+interface articleProperties {
+  title: string;
+  description: string;
+  profileImage: string;
+  name: string;
+  time: string;
+  creationDate: string;
+  image: string;
+  link: string;
+  tag: string;
 }
 
-export default function LatestArticle({ article }: { article: props }) {
-    return (
-        <Link to={article.link}>
-            <article className="text-muted-foreground max-w-[792px] bg-[#fafafa]">
-                <div className="grid md:grid-cols-5 gap-[24px] md:py-[32px] py-[16px]">
-                    <div className="order-2 md:order-1 md:col-span-3 space-y-[8px] md:space-y-[16px]">
-                        <span className="bg-border pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
-                            <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
-                            <div className="uppercase">
-                                {article.tag}
-                            </div>
-                        </span>
+export default function LatestArticle({
+  article,
+}: {
+  article: articleProperties;
+}) {
+  return (
+    <Link to={article.link}>
+      <article className="max-w-[792px] bg-[#fafafa] text-muted-foreground">
+        <div className="grid gap-[24px] py-[16px] md:grid-cols-5 md:py-[32px]">
+          <div className="order-2 space-y-[8px] md:order-1 md:col-span-3 md:space-y-[16px]">
+            <span className="inline-flex items-center justify-center gap-[6px] rounded-full bg-border py-[4px] pl-[10px] pr-[12px] text-[12px] font-[700]">
+              <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+              <div className="uppercase">{article.tag}</div>
+            </span>
 
-                        <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal] tracking-wider">
-                            {article.title}
-                        </h3>
+            <h3 className="text-[20px] font-[700] capitalize leading-[normal] tracking-wider md:text-[28px] md:font-[600]">
+              {article.title}
+            </h3>
 
-                        <p className="font-[400] text-[14px] md:text-[18px] leading-[normal] tracking-wide">
-                            {article.description}
-                        </p>
+            <p className="text-[14px] font-[400] leading-[normal] tracking-wide md:text-[18px]">
+              {article.description}
+            </p>
 
-                        <div className="flex md:justify-between items-center gap-[16px] md:gap-0 flex-wrap font-[500] text-[14px] md:text-[16px]">
-                            <div className="flex items-center gap-[12px] w-full md:w-auto order-3 md:order-1">
-                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[32px] md:w-[40px] h-[32px] md:h-[40px] object-cover object-top" />
-                                <p className="">
-                                    {article.name}
-                                </p>
-                            </div>
-                            <p className="order-1 md:order-2">
-                                {article.time}
-                                {" "}
-                                Read
-                            </p>
+            <div className="flex flex-wrap items-center gap-[16px] text-[14px] font-[500] md:justify-between md:gap-0 md:text-[16px]">
+              <div className="order-3 flex w-full items-center gap-[12px] md:order-1 md:w-auto">
+                <img
+                  src={article.profileImage}
+                  alt={article.name}
+                  className="h-[32px] w-[32px] rounded-full object-cover object-top md:h-[40px] md:w-[40px]"
+                />
+                <p className="">{article.name}</p>
+              </div>
+              <p className="order-1 md:order-2">{article.time} Read</p>
 
-                            <p className="order-2 md:order-3">
-                                {article.creationDate}
-                            </p>
-                        </div>
-
-                    </div>
-                    <div className="order-1 md:order-2 md:col-span-2 flex md:items-end">
-                        <img src={article.image} alt={article.title} className="w-full md:h-[250px] h-[230px] object-cover rounded-[6px] md:rounded-[8px]" />
-                    </div>
-                </div>
-            </article>
-        </Link>
-    )
+              <p className="order-2 md:order-3">{article.creationDate}</p>
+            </div>
+          </div>
+          <div className="order-1 flex md:order-2 md:col-span-2 md:items-end">
+            <img
+              src={article.image}
+              alt={article.title}
+              className="h-[230px] w-full rounded-[6px] object-cover md:h-[250px] md:rounded-[8px]"
+            />
+          </div>
+        </div>
+      </article>
+    </Link>
+  );
 }

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -15,10 +15,10 @@ interface props {
 export default function LatestArticle({ article }: { article: props }) {
     return (
         <Link to={article.link}>
-            <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
-                <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
-                    <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
-                        <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
+            <article className="text-muted-foreground max-w-[1000px] bg-[#fafafa]">
+                <div className="grid md:grid-cols-2 gap-[24px] md:py-[32px] py-[16px]">
+                    <div className="order-2 md:order-1 space-y-[8px] md:space-y-[16px]">
+                        <span className="bg-border pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
                             <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
                             <div className="uppercase">
                                 {article.tag}
@@ -33,27 +33,27 @@ export default function LatestArticle({ article }: { article: props }) {
                             {article.description}
                         </p>
 
-                        <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
-                            <div className="flex items-center gap-[8px]">
-                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
-                                <p className="font-[500] text-center">
+                        <div className="flex md:justify-between items-center gap-[16px] md:gap-0 flex-wrap font-[500] text-[14px] md:text-[16px]">
+                            <div className="flex items-center gap-[12px] w-full md:w-auto order-3 md:order-1">
+                                <img src={article.profileImage} alt={article.name} className="rounded-full w-[32px] md:w-[40px] h-[32px] md:h-[40px] object-cover object-top" />
+                                <p className="">
                                     {article.name}
                                 </p>
                             </div>
-                            <p className="text-center">
+                            <p className="order-1 md:order-2">
                                 {article.time}
                                 {" "}
                                 Read
                             </p>
 
-                            <p className="text-center">
+                            <p className="order-2 md:order-3">
                                 {article.creationDate}
                             </p>
                         </div>
 
                     </div>
-                    <div className="flex items-center">
-                        <img src={article.image} alt={article.title} className="w-full md:h-[300px] h-[250px] object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
+                    <div className="order-1 md:order-2 flex md:items-end">
+                        <img src={article.image} alt={article.title} className="w-full md:h-[250px] h-[230px] object-cover rounded-[6px] md:rounded-[8px]" />
                     </div>
                 </div>
             </article>

--- a/app/components/article/LatestArticle.tsx
+++ b/app/components/article/LatestArticle.tsx
@@ -1,0 +1,58 @@
+interface props {
+    title: string;
+    description: string;
+    profileImage: string;
+    name: string;
+    time: string;
+    creationDate: string;
+    image: string;
+    link: string;
+    tag: string;
+}
+
+export default function LatestArticle({ article }: { article: props }) {
+    return (
+        <article className="text-[#525252] max-w-[1000px] bg-[#fafafa]">
+            <div className="grid md:grid-cols-2 gap-[24px] p-[24px] md:border-b-[1px] border-[#525252]">
+                <div className="space-y-[16px] md:px-[8px] lg:p-[16px] p-[16px]">
+                    <span className="bg-[#F97316] pl-[10px] pr-[12px] py-[4px] rounded-full inline-flex justify-center items-center gap-[6px] text-[12px] font-[700]">
+                        <span className="h-[8px] w-[8px] rounded-full bg-black"></span>
+                        <div className="uppercase">
+                            {article.tag}
+                        </div>
+                    </span>
+
+                    <h3 className="md:text-[28px] text-[20px] md:font-[600] font-[700] capitalize leading-[normal]">
+                        {article.title}
+                    </h3>
+
+                    <p className="font-[400] text-[14px] md:text-[18px] leading-[normal]">
+                        {article.description}
+                    </p>
+
+                    <div className="flex justify-between items-center md:font-[500] font-[400] text-[14px] md:text-[16px]">
+                        <div className="flex items-center gap-[8px]">
+                            <img src={article.profileImage} alt={article.name} className="rounded-full w-[24px] md:w-[40px] h-[24px] md:h-[40px] object-cover object-top" />
+                            <p className="font-[500] text-center">
+                                {article.name}
+                            </p>
+                        </div>
+                        <p className="text-center">
+                            {article.time}
+                            {" "}
+                            Read
+                        </p>
+
+                        <p className="text-center">
+                            {article.creationDate}
+                        </p>
+                    </div>
+
+                </div>
+                <div className="flex items-stretch">
+                    <img src={article.image} alt={article.title} className="w-full h-full object-cover rounded-[6px] md:rounded-[8px] border-b-[1px] md:border-0 border-[#525252]" />
+                </div>
+            </div>
+        </article>
+    )
+}


### PR DESCRIPTION
### What I was asked to do
Implement a reusable latest acticle card component that accepts props of the card content as seen in the design. Implement both the web and mobile view of the component.

![349564423-091def26-31bd-4d38-a2f4-827104bb5174](https://github.com/user-attachments/assets/e7e8519b-794d-4792-be6c-122ed6b661e7)

[**Link to issue**](https://github.com/hngprojects/hng_boilerplate_remix/issues/26)
[Figma design - components page](https://www.figma.com/design/VEItfX6St5NSAqqNHImcxD/HNG-Boilerplate-Designs?node-id=2202-25505&m=dev)

### What I did
Implemented the reusable latest article card component as seen in the figma design which receives the following props:

title: string;
description: string;
profileImage: string;
name: string;
time: string;
creationDate: string;
image: string;
link: string;
tag: string;
The component can be located at /app/components/article/LatestArticle.tsx

This is the link to the design
[https://www.figma.com/design/VEItfX6St5NSAqqNHImcxD/HNG-Boilerplate-Designs?node-id=2202-25505&m=dev](https://www.figma.com/design/VEItfX6St5NSAqqNHImcxD/HNG-Boilerplate-Designs?node-id=2202-25505&m=dev)

Below are the images to the developed component and the lint image
![developed design](https://github.com/user-attachments/assets/1c993ace-fc81-47ce-bc68-ac43ab5d6b10)

![lint](https://github.com/user-attachments/assets/f36a0c71-2de2-43f6-aa9b-4fc8ceceb579)

