### PR TITLE
fix: added left-0 to FooterCookieConsent component to ensure it start…

### DIFF
--- a/app/components/ui/footerCookieConsent.tsx
+++ b/app/components/ui/footerCookieConsent.tsx
@@ -16,7 +16,7 @@ const handleSettings = () => {
 
 const FooterCookieConsent: FC = () => {
   return (
-    <div className="fixed bottom-0 w-full border-t border-gray-200 bg-white p-6 text-gray-900">
+    <div className="fixed left-0 bottom-0 w-full border-t border-gray-200 bg-white p-6 text-gray-900">
       <div className="flex flex-col items-start space-y-4 md:flex-row md:items-center md:justify-between md:space-x-4 md:space-y-0">
         <p className="flex flex-1 flex-col text-left text-sm">
           <span className="text-sm font-bold sm:text-xl">

--- a/app/components/ui/footerCookieConsent.tsx
+++ b/app/components/ui/footerCookieConsent.tsx
@@ -16,7 +16,7 @@ const handleSettings = () => {
 
 const FooterCookieConsent: FC = () => {
   return (
-    <div className="fixed left-0 bottom-0 w-full border-t border-gray-200 bg-white p-6 text-gray-900">
+    <div className="fixed bottom-0 left-0 w-full border-t border-gray-200 bg-white p-6 text-gray-900">
       <div className="flex flex-col items-start space-y-4 md:flex-row md:items-center md:justify-between md:space-x-4 md:space-y-0">
         <p className="flex flex-1 flex-col text-left text-sm">
           <span className="text-sm font-bold sm:text-xl">


### PR DESCRIPTION

**[FEAT] External static page > Floating footer cookie consent component #28**
https://github.com/hngprojects/hng_boilerplate_remix/issues/28

# Changes proposed

## What were you told to do?

Implement a floating footer cookie consent component 

## What did you do?

- Added a `left-0` class to the `FooterCookieConsent` component to ensure it starts from the left edge.
- Ensured the component is responsive.
- Utilized existing button components for design consistency.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **dev branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos



![Frame 1618873047](https://github.com/user-attachments/assets/f43bb77a-0892-4559-ae5c-9e5617899957)


Video
![video](https://drive.google.com/file/d/1lerfktP-B6dx4_CVGAgpxvxbS3CCDrCH/view?usp=sharing)
![1-Test for footer cookie consent component](https://github.com/user-attachments/assets/22a24d10-312b-4b33-821f-831bfcec6f62)

