### PR TITLE
fix: remove navbar in /blog/latest page

### DIFF
--- a/app/routes/blog.latest/index.tsx
+++ b/app/routes/blog.latest/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 
 import LatestArticle from "~/components/article/LatestArticle";
 import Button from "~/components/customButton/customButton";
-import Navbar from "~/components/static-navbar/static-navbar";
 import { Article, fetchArticles } from "./api-call";
 
 export default function ArticlesPage() {
@@ -48,7 +47,6 @@ export default function ArticlesPage() {
 
   return (
     <div className="">
-      <Navbar isUserAuthenticated={false} />
       <div className="flex h-auto w-full flex-col gap-6 bg-background px-6 py-9 text-muted-foreground lg:items-center">
         <h1 className="text-[28px] font-bold text-neutral-1">
           Latest Articles


### PR DESCRIPTION
### Removed navbar from the page since there is a global navbar
![nav](https://github.com/user-attachments/assets/e23c75fa-ffca-464a-90b9-2c4c96d79da8)

![lint3](https://github.com/user-attachments/assets/6d244de7-936c-451e-b228-662a1493537e)
